### PR TITLE
Simple fix for "literal" JSON from treenexus

### DIFF
--- a/views/generic.json
+++ b/views/generic.json
@@ -11,7 +11,7 @@ try:
                 response.write(line,escape=False)
 	    pass
         else:
-            response.write(json(full_response),escape=False)
+            response.write(full_response,escape=False)
 	pass
     else:
         response.write(json(response._vars),escape=False)


### PR DESCRIPTION
@leto: This fixes the encoded "giant string" response for github_client.fetch_study, returning a literal, diff-friendly JSON with all newlines, etc.
