### PR TITLE
Implement search controller which uses OTI

### DIFF
--- a/controllers/search.py
+++ b/controllers/search.py
@@ -1,21 +1,52 @@
 import os
 import time
 import json
+import requests
 from githubsearch import GithubSearch
+from oti_search import OTISearch
+from ConfigParser import SafeConfigParser
 
 @request.restful()
 def v1():
     "The OpenTree API v1"
     response.view = 'generic.json'
+    app_name = "api"
+    conf = SafeConfigParser({})
+    if os.path.isfile("%s/applications/%s/private/localconfig" % (os.path.abspath('.'), app_name,)):
+        conf.read("%s/applications/%s/private/localconfig" % (os.path.abspath('.'), app_name,))
+    else:
+        conf.read("%s/applications/%s/private/config" % (os.path.abspath('.'), app_name,))
 
-    def GET(search_term,jsoncallback=None,callback=None,_=None,**kwargs):
-        "OpenTree API methods relating to searching"
+    host = conf.get("apis","oti_host")
+    port = conf.get("apis","oti_port")
+
+    api_base_url = "http://%s:%s/db/data/ext/QueryServices/graphdb/" % (host, port)
+    oti = OTISearch(api_base_url)
+
+    def GET(kind, property_name, search_term,jsoncallback=None,callback=None,_=None,**kwargs):
+        """"OpenTree API methods relating to searching
+Example:
+
+    http://localhost:8000/api/search/v1/tree/ot-ottTaxonName/Carex
+    http://localhost:8000/api/search/v1/node/ot-ottId/1000455
+
+When searching for a property name ot:foo, ot-foo must be used
+because web2py does not recognize URLs that contain a colon
+other than specifying a port, even if URL encoded.
+
+"""
 
         # support JSONP request from another domain
         if jsoncallback or callback:
             response.view = 'generic.jsonp'
 
-        gs = GithubSearch()
-        return gs.search(search_term)
+        # colons don't play nicely with GET requests
+        property_name = property_name.replace("-",":")
+
+        valid_kinds = ["study", "tree", "node"]
+        if kind in valid_kinds:
+            return oti.do_search(kind, property_name, search_term)
+        else:
+            raise HTTP(400,json.dumps({"error":1, "description":"not a valid property name"}))
 
     return locals()

--- a/modules/oti_search.py
+++ b/modules/oti_search.py
@@ -1,0 +1,29 @@
+import simplejson as json
+import os
+import requests
+
+class OTISearch(object):
+    def __init__(self, api_base_url):
+        self.api_base_url = api_base_url;
+
+    def do_search(self, kind, key, value):
+        kind_to_oti_url = {
+            "tree": "singlePropertySearchForTrees/",
+            "node": "singlePropertySearchForTreeNodes/",
+            "study": "singlePropertySearchForStudies/"
+        }
+
+        headers = {
+            'content-type': 'application/json',
+            'accept':       'application/json',
+        }
+        search_url = self.api_base_url + kind_to_oti_url[kind]
+        data = { "property": key, "value": value }
+
+        r = requests.post(search_url, headers=headers, data=json.dumps(data), allow_redirects=True)
+        try:
+            response = r.json()
+        except:
+            return json.dumps({"error": 1})
+
+        return response

--- a/modules/test_oti_search.py
+++ b/modules/test_oti_search.py
@@ -1,0 +1,59 @@
+import unittest
+import os, sys
+from oti_search import OTISearch
+from ConfigParser import SafeConfigParser
+
+class TestOTISearch(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        conf = SafeConfigParser({})
+        if os.path.isfile("../private/localconfig"):
+            conf.read("../private/localconfig")
+        else:
+            conf.read("../private/config")
+
+        self.host = conf.get("apis","oti_host")
+        self.port = conf.get("apis","oti_port")
+
+        self.api_base_url = "http://%s:%s/db/data/ext/QueryServices/graphdb/" % (self.host, self.port)
+        self.oti = OTISearch(self.api_base_url)
+
+    def test_tree(self):
+        json = self.oti.do_search("tree",
+            key="ot:ottTaxonName",
+            value="Carex"
+        )
+        self.assertTrue("results" in json)
+        results = json["results"]
+        self.assertIsInstance(results, type(list()))
+
+    def test_node(self):
+        json = self.oti.do_search("node",
+            key="ot:ottId",
+            value="1000455",
+        )
+        self.assertTrue("results" in json)
+        results = json["results"]
+        self.assertIsInstance(results, type(list()))
+
+    def test_study(self):
+        json = self.oti.do_search("study",
+            key="ot:studyPublicationReference",
+            value="vorontsova"
+        )
+        self.assertTrue("results" in json)
+        results = json["results"]
+        self.assertIsInstance(results, type(dict()))
+
+def suite():
+    loader = unittest.TestLoader()
+    testsuite = loader.loadTestsFromTestCase(TestOTISearch)
+    return testsuite
+
+def test_main():
+    testsuite = suite()
+    runner = unittest.TextTestRunner(sys.stdout, verbosity=2)
+    result = runner.run(testsuite)
+
+if __name__ == "__main__":
+    test_main()

--- a/private/config.example
+++ b/private/config.example
@@ -8,4 +8,5 @@ github_client_id = YOUR_CLIENT_ID_HERE
 github_client_secret = YOUR_CLIENT_SECRET_HERE
 # These values can be obtained by registering your instance as an
 # application with GitHub, at https://github.com/settings/applications/new
-
+oti_host    = localhost
+oti_port    = 7474


### PR DESCRIPTION
This search controller uses OpenTree Index (https://github.com/chinchliff/oti/) which
requires that neo4j be running and that the NexSON files have been indexed.

This controller also requires that the host and port of the neo4j instance be specified
in private/config. An example is given in private/config.example .
