### PR TITLE
Improved error messages, waiver/license changes to match opentree

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -426,21 +426,21 @@ def v1():
             elif using_existing_license:
                 existing_license = kwargs.get('alternate_license', '')
                 if existing_license == 'CC-0':
-                    nexml['^xhtml:license'] = {'@href': 'http://creativecommons.org/publicdomain/zero/1.0/'}
+                    nexml['^xhtml:license'] = {'@name': 'CC0', '@href': 'http://creativecommons.org/publicdomain/zero/1.0/'}
                     pass
                 elif existing_license == 'CC-BY-2.0':
-                    nexml['^xhtml:license'] = {'@href': 'http://creativecommons.org/licenses/by/2.0/'}
+                    nexml['^xhtml:license'] = {'@name': 'CC-BY 2.0', '@href': 'http://creativecommons.org/licenses/by/2.0/'}
                     pass
                 elif existing_license == 'CC-BY-2.5':
-                    nexml['^xhtml:license'] = {'@href': 'http://creativecommons.org/licenses/by/2.5/'}
+                    nexml['^xhtml:license'] = {'@name': 'CC-BY 2.5', '@href': 'http://creativecommons.org/licenses/by/2.5/'}
                     pass
                 elif existing_license == 'CC-BY-3.0':
-                    nexml['^xhtml:license'] = {'@href': 'http://creativecommons.org/licenses/by/3.0/'}
+                    nexml['^xhtml:license'] = {'@name': 'CC-BY 3.0', '@href': 'http://creativecommons.org/licenses/by/3.0/'}
                     pass
                 # NOTE that we don't offer CC-BY 4.0, which is problematic for data
                 elif existing_license == 'CC-BY':
                     # default to version 3, if not specified. 
-                    nexml['^xhtml:license'] = {'@href': 'http://creativecommons.org/licenses/by/3.0/'}
+                    nexml['^xhtml:license'] = {'@name': 'CC-BY 3.0', '@href': 'http://creativecommons.org/licenses/by/3.0/'}
                     pass
                 else:  # assume it's something else
                     alt_license_name = kwargs.get('alt_license_name', '')


### PR DESCRIPTION
This ensures compatibility with the newest curation app, esp. the waiver/license changes here:
https://github.com/OpenTreeOfLife/opentree/pull/401
