### PR TITLE
Prepend missing scheme to oti base URL, if needed.

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -159,9 +159,13 @@ def _fetch_duplicate_study_ids(study_DOI=None, study_ID=None):
     else:
         conf.read("%s/applications/%s/private/config" % (os.path.abspath('.'), app_name,))
     oti_base_url = conf.get("apis", "oti_base_url")
+    fetch_url = '%s/singlePropertySearchForStudies' % oti_base_url
+    if fetch_url.startswith('//'):
+        # Prepend scheme to a scheme-relative URL
+        fetch_url = "http:%s" % fetch_url
     try:
         dupe_lookup_response = fetch(
-            '%s/singlePropertySearchForStudies' % oti_base_url,
+            fetch_url,
             data={
                 "property": "ot:studyPublication",
                 "value": study_DOI,


### PR DESCRIPTION
This correctly handles a scheme-relative URL by prepending 'http:'

Reminder: We typically define all API base URLs as scheme-relative, so that client-side calls will conform to the current scheme (HTTP or HTTPS) used in the browser. Since server-side calls also use these URLs, we need to prepend a proper scheme to avoid errors.
