### PR TITLE
Add more information to webhook failure message

### DIFF
--- a/bin/add_or_update_webhooks.py
+++ b/bin/add_or_update_webhooks.py
@@ -56,7 +56,7 @@ if not(prompt_for_manual_webhooks):
     if found_matching_webhook:
         print "Found a matching webhook in the docstore repo!"
         sys.exit(0)
-    else if prompt_for_manual_webhooks == False:
+    elif prompt_for_manual_webhooks == False:
         print "Adding a webhook to the docstore repo..."
         hook_settings = {
             "name": "web",


### PR DESCRIPTION
A failure to retrieve the phylsystem repo's existing webhooks will now return the complete JSON response, which is much more helpful: For example:

```
Unexpected webhook response:  {"message":"Bad credentials","documentation_url":"https://developer.github.com/v3"}
```
