### PR TITLE
Add missing anyjson module.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ sh==1.08
 simplejson>=3.3.1
 locket==0.1.1
 dogpile.cache>=0.5.3
-
+anyjson


### PR DESCRIPTION
For better or worse, we use this in addition to simplejson. This
apparently has worked in the past because of peyotl's requirements.txt
file.
