### PR TITLE
Ignore invalid DOI when creating a study

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -529,7 +529,7 @@ def v1():
                 new_study_nexson = get_empty_nexson(BY_ID_HONEY_BADGERFISH, include_cc0=cc0_agreement)
                 if publication_doi:
                     # submitter entered an invalid DOI (or other URL); add it now
-                    nexson['nexml'][u'^ot:studyPublication'] = {'@href': publication_doi}
+                    new_study_nexson['nexml'][u'^ot:studyPublication'] = {'@href': publication_doi}
 
             nexml = new_study_nexson['nexml']
 


### PR DESCRIPTION
If someone enters an invalid DOI, or another URL entirely, don't bother trying to retrieve its publication reference info from CrossRef.org. 

Instead, create a blank study "from scratch" and apply the DOI/URL exactly as entered.

Fixes https://github.com/OpenTreeOfLife/opentree/issues/424
