### PR TITLE
Returning 400 if the resource_id to push is bogus

### DIFF
--- a/controllers/push.py
+++ b/controllers/push.py
@@ -35,7 +35,13 @@ def v1():
                 _LOG.warn('push failure file "{f}" already exists. This event not logged there'.format(f=fail_file))
             else:
                 timestamp = datetime.datetime.utcnow().isoformat()
-                ga = phylesystem.create_git_action(resource_id)
+                try:
+                    ga = phylesystem.create_git_action(resource_id)
+                except:
+                    m = 'Could not create an adaptor for git actions on study ID "{}". ' \
+                        'If you are confident that this is a valid study ID, please report this as a bug.'
+                    m = m.format(resource_id)
+                    raise HTTP(400, json.dumps({'error': 1, 'description': m}))
                 master_sha = ga.get_master_sha()
                 obj = {'date': timestamp,
                        'study': resource_id,


### PR DESCRIPTION
This exception deals with bogus requests nicely (failure
to put the resource_id in the right spot in the URL).
If we have some sort of deep problem that causes the
phylesystem to be not pushing (or being able to create git_actions
at all), then these will NOT be logged. So we won't be able
to detect them with our pushes_succeeding check.  However,
such a state would probably not be responding to GETs, so
we'd probably notice in other ways...
