### PR TITLE
Fix unversioned indexing URLs to "back out" of v1/

### DIFF
--- a/controllers/search.py
+++ b/controllers/search.py
@@ -124,7 +124,8 @@ N.B. This depends on a GitHub webhook on the chosen docstore.
     add_or_update_ids = list(set(add_or_update_ids))  # remove any duplicates
 
     if len(add_or_update_ids) > 0:
-        nudge_url = "%s/ext/IndexServices/graphdb/indexNexsons" % (oti_base_url,)
+        # N.B. The indexing service lives outside of the v1/ space, so we "back out" these URLs with ".."
+        nudge_url = "%s/../ext/IndexServices/graphdb/indexNexsons" % (oti_base_url,)
         nexson_urls = [ (nexson_url_template % (study_id,)) for study_id in add_or_update_ids ]
 
         # N.B. that gluon.tools.fetch() can't be used here, since it won't send
@@ -152,7 +153,8 @@ nexson_urls: %s
 
     if len(removed_study_ids) > 0:
         # Un-index the studies that were removed from docstore
-        remove_url = "%s/ext/IndexServices/graphdb/unindexNexsons" % (oti_base_url,)
+        # N.B. The indexing service lives outside of the v1/ space, so we "back out" these URLs with ".."
+        remove_url = "%s/../ext/IndexServices/graphdb/unindexNexsons" % (oti_base_url,)
         req = urllib2.Request(
             url=remove_url, 
             data=json.dumps({


### PR DESCRIPTION
Addresses #130. This should fix our failed oti indexing (and un-indexing) calls when saving study changes.
