### PR TITLE
Clear cached study list after any CRUD operation.

### DIFF
--- a/controllers/search.py
+++ b/controllers/search.py
@@ -175,6 +175,10 @@ removed_study_ids: %s
 
         # TODO: check returned IDs against our original list... what if something failed?
 
+    # Clear any cached study lists (both verbose and non-verbose)
+    cache.ram.clear(regex="cached:.*/findAllStudies:")
+    print 'CLEARED CACHED STUDY LIST!'
+
     github_webhook_url = "%s/settings/hooks" % opentree_docstore_url
     full_msg = """This URL should be called by a webhook set in the docstore repo:
 <br /><br />


### PR DESCRIPTION
This makes sure that our cached study list stays fresh, by clearing
cached data each time it triggers updates to OTI. (This works with a
[corresponding `cache-study-list` PR in the main 'opentree' repo](https://github.com/OpenTreeOfLife/opentree/pull/762).)