### PR TITLE
In tests, move first service path component out of config and into each individual test

### DIFF
--- a/ws-tests/config_test_study_push.py
+++ b/ws-tests/config_test_study_push.py
@@ -4,7 +4,7 @@ from opentreetesting import test_http_json_method, config
 #This test should only pass if filesize is set very low in the config and/or max tree number is set to 0
 DOMAIN = config('host', 'apihost')
 study = '10'
-SUBMIT_URI = DOMAIN + '/v1/study/' + study
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/' + study
 data = {'output_nexml2json':'1.2'}
 r = test_http_json_method(SUBMIT_URI,
                           'GET',

--- a/ws-tests/config_test_valid_study_put.py
+++ b/ws-tests/config_test_valid_study_put.py
@@ -9,14 +9,14 @@ import os
 # this makes it easier to test concurrent pushes to different branches
 DOMAIN = config('host', 'apihost')
 study_id = '10'
-SUBMIT_URI = DOMAIN + '/v1/study/' + study_id
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/' + study_id
 data = {'output_nexml2json':'1.0.0'}
 r = test_http_json_method(SUBMIT_URI, 'GET', data=data, expected_status=200, return_bool_data=True)
 if not r[0]:
     sys.exit(0)
 resp = r[1]
 starting_commit_SHA = resp['sha']
-SUBMIT_URI = DOMAIN + '/v1/study/{s}'.format(s=study_id)
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/{s}'.format(s=study_id)
 n = resp['data']
 # refresh a timestamp so that the test generates a commit
 m = n['nexml']['^bogus_timestamp'] = datetime.datetime.utcnow().isoformat()

--- a/ws-tests/get_study.py
+++ b/ws-tests/get_study.py
@@ -3,7 +3,7 @@ import sys, os, json
 from opentreetesting import config, get_obj_from_http
 DOMAIN = config('host', 'apihost')
 for study_id in sys.argv[1:]:
-    SUBMIT_URI = DOMAIN + '/v1/study/' + study_id
+    SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/' + study_id
     data = {'output_nexml2json':'1.2'}
     x = get_obj_from_http(SUBMIT_URI, 
                           'GET',

--- a/ws-tests/global.test.conf
+++ b/ws-tests/global.test.conf
@@ -1,3 +1,3 @@
 [host]
-apihost = http://dev.opentreeoflife.org/phylesystem
+apihost = http://devapi.opentreeoflife.org
 parentsha = f604e027cdd0ada6638e620206a9f44edbabeff3

--- a/ws-tests/local.test.conf
+++ b/ws-tests/local.test.conf
@@ -1,5 +1,5 @@
 [host]
-apihost = http://127.0.0.1:8000/phylesystem
+apihost = http://127.0.0.1:8000
 
 # hbf_phylesystem_test
 #parentsha = f604e027cdd0ada6638e620206a9f44edbabeff3

--- a/ws-tests/opentreetesting.py
+++ b/ws-tests/opentreetesting.py
@@ -54,6 +54,8 @@ def parse_argv_as_options(_CONFIG):
         if len(equatands) == 2:
             sec_param = equatands[0].split(':')
             if len(sec_param) == 2:
+                if not _CONFIG.has_section(sec_param[0]):
+                    _CONFIG.add_section(sec_param[0])
                 _CONFIG.set(sec_param[0], sec_param[1], equatands[1])
             else:
                 sys.stderr.write('Command line argument %s not in form section:parameter=value' % (arg))

--- a/ws-tests/opentreetesting.py
+++ b/ws-tests/opentreetesting.py
@@ -109,13 +109,13 @@ def get_obj_from_http(url,
         }
     if data:
         resp = requests.request(verb,
-                                url,
+                                translate(url),
                                 headers=headers,
                                 data=json.dumps(data),
                                 allow_redirects=True)
     else:
         resp = requests.request(verb,
-                                url,
+                                translate(url),
                                 headers=headers,
                                 allow_redirects=True)
     debug('Sent {v} to {s}\n'.format(v=verb, s=resp.url))
@@ -147,13 +147,13 @@ def test_http_json_method(url,
         }
     if data:
         resp = requests.request(verb,
-                                url,
+                                translate(url),
                                 headers=headers,
                                 data=json.dumps(data),
                                 allow_redirects=True)
     else:
         resp = requests.request(verb,
-                                url,
+                                translate(url),
                                 headers=headers,
                                 allow_redirects=True)
         debug('Sent {v} to {s}\n'.format(v=verb, s=resp.url))
@@ -209,3 +209,26 @@ def exit_if_api_is_readonly(fn):
     else:
         sys.stderr.write('s')
     sys.exit(0)
+
+
+# Mimic the behavior of apache so that services can be tested without
+# having apache running.  See opentree/deploy/setup/opentree-shared.conf
+
+translations = [('/v2/study/', '/phylesystem/v1/study/'),
+                ('/cached/', '/phylesystem/default/cached/'),
+                # treemachine
+                ('/v2/tree_of_life/', '/db/data/ext/tree_of_life/graphdb/'),
+                ('/v2/graph/', '/db/data/ext/graph/graphdb/'),
+                # taxomachine
+                ('/v2/tnrs/', '/db/data/ext/tnrs_v2/graphdb/'),
+                ('/v2/taxonomy/', '/db/data/ext/taxonomy/graphdb/'),
+                # oti
+                ('/v2/studies/', '/db/data/ext/studies/graphdb/'),
+]
+
+def translate(s):
+    if config('host', 'translate', 'false') == 'true':
+        for (src, dst) in translations:
+            if s.startswith(src):
+                return dst + s[len(src):]
+    return s

--- a/ws-tests/test_api_root.py
+++ b/ws-tests/test_api_root.py
@@ -2,6 +2,7 @@
 import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
-if test_http_json_method(DOMAIN, 'GET', expected_status=200):
+SUBMIT_URI = '{d}/phylesystem'.format(d=DOMAIN)
+if test_http_json_method(SUBMIT_URI, 'GET', expected_status=200):
     sys.exit(0)
 sys.exit(1)

--- a/ws-tests/test_empty_study_put.py
+++ b/ws-tests/test_empty_study_put.py
@@ -2,7 +2,7 @@
 import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/99'
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/pg_99'
 data = { 'auth_token': os.environ.get('GITHUB_OAUTH_TOKEN', 'bogus_token')
 }
 if test_http_json_method(SUBMIT_URI, 'PUT', data, expected_status=400): #expected_response={}):

--- a/ws-tests/test_external_url.py
+++ b/ws-tests/test_external_url.py
@@ -2,7 +2,7 @@
 import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/external_url/99'
+SUBMIT_URI = DOMAIN + '/phylesystem/external_url/pg_99'
 print SUBMIT_URI
 r = test_http_json_method(SUBMIT_URI,
                           'GET',

--- a/ws-tests/test_file_get.py
+++ b/ws-tests/test_file_get.py
@@ -9,7 +9,7 @@ elif '/devapi.opentree' in DOMAIN:
 else:
     study = 'pg_90'
 # '/file' means get list of supplementary files
-SUBMIT_URI = '{d}/v1/study/{s}/file'.format(d=DOMAIN, s=study)
+SUBMIT_URI = '{d}/phylesystem/v1/study/{s}/file'.format(d=DOMAIN, s=study)
 r = test_http_json_method(SUBMIT_URI,
                           'GET',
                           expected_status=200,

--- a/ws-tests/test_integration.py
+++ b/ws-tests/test_integration.py
@@ -9,9 +9,9 @@ import os
 
 
 
-study_id = '99'
+study_id = 'pg_99'
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/{s}'.format(s=study_id)
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/{s}'.format(s=study_id)
 #A full integration test, with GET, PUT, POST, MERGE and a merge conflict, 
 #test get and save sha
 data = {'output_nexml2json':'1.2'}
@@ -52,7 +52,7 @@ r2_sha=r2[1]['sha']
 
 #Now get the outcome of the Merge, so that a curator could look at it.
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/{s}'.format(s=study_id)
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/{s}'.format(s=study_id)
 
 data = {
         'output_nexml2json':'1.2',
@@ -99,7 +99,7 @@ assert(len(rg1[1]['branch2sha'])>=2)
 # but not for other studies...
 alt_study_id='10'
 data = {'output_nexml2json':'1.2'}
-alt_SUBMIT_URI = DOMAIN + '/v1/study/{s}'.format(s=alt_study_id)
+alt_SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/{s}'.format(s=alt_study_id)
 rg2 = test_http_json_method(alt_SUBMIT_URI, 'GET', data=data, expected_status=200, return_bool_data=True)
 assert(rg2[0]==True)
 assert(len(rg2[1]['branch2sha'])==1)
@@ -150,7 +150,7 @@ r5_sha=r5[1]['sha']
 # sixth commit is the merge
 DOMAIN = config('host', 'apihost')
 starting_commit_SHA = r5_sha
-SUBMIT_URI = DOMAIN + '/merge/v1/{s}/{scs}'.format(s=study_id,scs=starting_commit_SHA)
+SUBMIT_URI = DOMAIN + '/phylesystem/merge/v1/{s}/{scs}'.format(s=study_id,scs=starting_commit_SHA)
 
 data = {
         'auth_token' :  os.environ.get('GITHUB_OAUTH_TOKEN', 'bogus_token'),
@@ -173,7 +173,7 @@ merged_sha = r6[1]['merged_sha']
         
 # add a 7th commit onto commit 6. This should NOT merge to master because we don't give it the secret arg.
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/{s}'.format(s=study_id)
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/{s}'.format(s=study_id)
 starting_commit_SHA = r6[1]['sha']
 zc += 1
 zcurr_obj["^zcount"] = zc
@@ -196,7 +196,7 @@ assert(r7[1]['merge_needed']==True)
         
 # add a 7th commit onto commit 6. This should merge to master because we don't give it the secret arg.
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/{s}'.format(s=study_id)
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/{s}'.format(s=study_id)
 starting_commit_SHA = r7[1]['sha']
 zc += 1
 zcurr_obj["^zcount"] = zc

--- a/ws-tests/test_invalid_merge.py
+++ b/ws-tests/test_invalid_merge.py
@@ -3,7 +3,7 @@ from opentreetesting import test_http_json_method, config
 import sys
 
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/merge/v1/master/master'
+SUBMIT_URI = DOMAIN + '/phylesystem/merge/v1/master/master'
 
 data = {
          'auth_token': 'bogus'

--- a/ws-tests/test_nonauth_study_put.py
+++ b/ws-tests/test_nonauth_study_put.py
@@ -10,7 +10,7 @@ import os
 study_id = 12
 
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/{s}'.format(s=study_id)
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/{s}'.format(s=study_id)
 fn = 'data/{s}.json'.format(s=study_id)
 inpf = codecs.open(fn, 'rU', encoding='utf-8')
 n = json.load(inpf)

--- a/ws-tests/test_nonnexson_study_put.py
+++ b/ws-tests/test_nonnexson_study_put.py
@@ -2,7 +2,7 @@
 import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/10'
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/10'
 data = { 'nexson': {'bogus' : 5},
          'auth_token': os.environ.get('GITHUB_OAUTH_TOKEN', 'bogus_token')
 

--- a/ws-tests/test_study_create_delete.py
+++ b/ws-tests/test_study_create_delete.py
@@ -7,7 +7,7 @@ import sys
 import os
 
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/'
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/'
 inpf = codecs.open('data/10.json', 'rU', encoding='utf-8')
 n = json.load(inpf)
 # refresh a timestamp so that the test generates a commit
@@ -33,7 +33,7 @@ c_id = resp['resource_id']
 print c_id
 
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/%s' % c_id
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/%s' % c_id
 data = {
          'auth_token': os.environ.get('GITHUB_OAUTH_TOKEN', 'bogus_token'),
          'starting_commit_SHA': starting_commit_SHA,

--- a/ws-tests/test_study_create_delete_message.py
+++ b/ws-tests/test_study_create_delete_message.py
@@ -7,7 +7,7 @@ import sys
 import os
 
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/'
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/'
 inpf = codecs.open('data/10.json', 'rU', encoding='utf-8')
 n = json.load(inpf)
 # refresh a timestamp so that the test generates a commit
@@ -33,7 +33,7 @@ c_id = resp['resource_id']
 print c_id
 
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/%s' % c_id
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/%s' % c_id
 data = {
          'auth_token': os.environ.get('GITHUB_OAUTH_TOKEN', 'bogus_token'),
          'starting_commit_SHA': starting_commit_SHA,

--- a/ws-tests/test_study_create_treebase.py
+++ b/ws-tests/test_study_create_treebase.py
@@ -9,7 +9,7 @@ import os
 exit_if_api_is_readonly(__file__)
 
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/'
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/'
 # refresh a timestamp so that the test generates a commit
 data = { 'import_method' : 'import-method-TREEBASE_ID',
         'import_from_location': 'IMPORT_FROM_TREEBASE',

--- a/ws-tests/test_study_get.py
+++ b/ws-tests/test_study_get.py
@@ -2,7 +2,7 @@
 import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/10'
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/10'
 data = {'output_nexml2json':'1.2'}
 if test_http_json_method(SUBMIT_URI, 'GET', data=data, expected_status=200):
     sys.exit(0)

--- a/ws-tests/test_study_get_404.py
+++ b/ws-tests/test_study_get_404.py
@@ -3,7 +3,7 @@ import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
 # study 1 does not exist
-SUBMIT_URI = DOMAIN + '/v1/study/1'
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/1'
 if test_http_json_method(SUBMIT_URI, 'GET', expected_status=404):
     sys.exit(0)
 sys.exit(1)

--- a/ws-tests/test_study_get_bad_outformat.py
+++ b/ws-tests/test_study_get_bad_outformat.py
@@ -2,7 +2,7 @@
 import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/10'
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/10'
 data = {'output_nexml2json':'x0.0.0'}
 if test_http_json_method(SUBMIT_URI, 'GET', data=data, expected_status=400):
     sys.exit(0)

--- a/ws-tests/test_study_get_multiformat.py
+++ b/ws-tests/test_study_get_multiformat.py
@@ -5,7 +5,7 @@ import json
 import sys
 import os
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/10'
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/10'
 data = {'output_nexml2json':'0.0.0'}
 pb = test_http_json_method(SUBMIT_URI, 
                            'GET',

--- a/ws-tests/test_study_list.py
+++ b/ws-tests/test_study_list.py
@@ -2,7 +2,7 @@
 import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/study_list'
+SUBMIT_URI = DOMAIN + '/phylesystem/study_list'
 #sys.stderr.write('Calling "{}"...\n'.format(SUBMIT_URI))
 r = test_http_json_method(SUBMIT_URI,
                           'GET',

--- a/ws-tests/test_study_push.py
+++ b/ws-tests/test_study_push.py
@@ -3,7 +3,7 @@ import sys, os
 from opentreetesting import test_http_json_method, config, exit_if_api_is_readonly
 DOMAIN = config('host', 'apihost')
 study = '10'
-SUBMIT_URI = DOMAIN + '/v1/study/' + study
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/' + study
 data = {'output_nexml2json':'1.2'}
 r = test_http_json_method(SUBMIT_URI,
                           'GET',

--- a/ws-tests/test_tree_get.py
+++ b/ws-tests/test_tree_get.py
@@ -2,7 +2,7 @@
 import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/10/tree/tree3.nex'
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/10/tree/tree3.nex'
 data = {'tip_label': 'ot:ottTaxonName'}
 r = test_http_json_method(SUBMIT_URI,
                           'GET',

--- a/ws-tests/test_tree_newick_get.py
+++ b/ws-tests/test_tree_newick_get.py
@@ -2,7 +2,7 @@
 import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v1/study/10/tree/tree3.tre'
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/10/tree/tree3.tre'
 data = {'tip_label': 'ot:ottTaxonName'}
 r = test_http_json_method(SUBMIT_URI,
                           'GET',

--- a/ws-tests/test_v2_studies_find_doi.py
+++ b/ws-tests/test_v2_studies_find_doi.py
@@ -2,7 +2,7 @@
 import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
-CONTROLLER = DOMAIN + '/studies'
+CONTROLLER = DOMAIN + '/phylesystem/studies'
 SUBMIT_URI = CONTROLLER + '/find_studies'
 p = {'verbose': True,
      'property': 'ot:studyPublication',

--- a/ws-tests/test_v2_studies_find_trees.py
+++ b/ws-tests/test_v2_studies_find_trees.py
@@ -2,7 +2,7 @@
 import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
-CONTROLLER = DOMAIN + '/studies'
+CONTROLLER = DOMAIN + '/phylesystem/studies'
 SUBMIT_URI = CONTROLLER + '/find_trees'
 p = {'verbose': True,
      'property': 'ot:ottId',

--- a/ws-tests/test_v2_studies_findall.py
+++ b/ws-tests/test_v2_studies_findall.py
@@ -2,7 +2,7 @@
 import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
-CONTROLLER = DOMAIN + '/studies'
+CONTROLLER = DOMAIN + '/phylesystem/studies'
 SUBMIT_URI = CONTROLLER + '/find_studies'
 r = test_http_json_method(SUBMIT_URI,
                           'GET',

--- a/ws-tests/test_v2_studies_properties.py
+++ b/ws-tests/test_v2_studies_properties.py
@@ -2,7 +2,7 @@
 import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
-CONTROLLER = DOMAIN + '/studies'
+CONTROLLER = DOMAIN + '/phylesystem/studies'
 SUBMIT_URI = CONTROLLER + '/properties'
 r = test_http_json_method(SUBMIT_URI,
                           'GET',

--- a/ws-tests/test_valid_study_put.py
+++ b/ws-tests/test_valid_study_put.py
@@ -9,14 +9,14 @@ import os
 # this makes it easier to test concurrent pushes to different branches
 DOMAIN = config('host', 'apihost')
 study_id = '10'
-SUBMIT_URI = DOMAIN + '/v1/study/' + study_id
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/' + study_id
 data = {'output_nexml2json':'1.0.0'}
 r = test_http_json_method(SUBMIT_URI, 'GET', data=data, expected_status=200, return_bool_data=True)
 if not r[0]:
     sys.exit(0)
 resp = r[1]
 starting_commit_SHA = resp['sha']
-SUBMIT_URI = DOMAIN + '/v1/study/{s}'.format(s=study_id)
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/{s}'.format(s=study_id)
 n = resp['data']
 # refresh a timestamp so that the test generates a commit
 m = n['nexml']['^bogus_timestamp'] = datetime.datetime.utcnow().isoformat()

--- a/ws-tests/test_valid_study_put_multiformat.py
+++ b/ws-tests/test_valid_study_put_multiformat.py
@@ -13,7 +13,7 @@ study_id = 12
 DOMAIN = config('host', 'apihost')
 starting_commit_SHA = config('host', 'parentsha')
 
-SUBMIT_URI = DOMAIN + '/v1/study/%s' % study_id
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/%s' % study_id
 fn = 'data/{s}.json'.format(s=study_id)
 inpf = codecs.open(fn, 'rU', encoding='utf-8')
 n = json.load(inpf)

--- a/ws-tests/test_valid_study_put_override_author.py
+++ b/ws-tests/test_valid_study_put_override_author.py
@@ -10,7 +10,7 @@ DOMAIN = config('host', 'apihost')
 starting_commit_SHA = config('host', 'parentsha')
 
 study_id="12"
-SUBMIT_URI = DOMAIN + '/v1/study/{s}'.format(s=study_id)
+SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/{s}'.format(s=study_id)
 fn = 'data/{s}.json'.format(s=study_id)
 inpf = codecs.open(fn, 'rU', encoding='utf-8')
 n = json.load(inpf)


### PR DESCRIPTION
Before this change, one writes in test.config:
   apihost=http://devapi.opentreeoflife.org/phylesystem
or whatever. After this change, one writes:
   apihost=http://devapi.opentreeoflife.org
Every individual test file had to be updated.

Purposes of this change: (1) prepare the way for v2 and v3 API testing, (2) make the test harness reuseable for use in other repositories.

Also part of this PR: update some study ids e.g. '99' is now 'pg_99'