### PR TITLE
fix the translate=true feature

### DIFF
--- a/ws-tests/README.md
+++ b/ws-tests/README.md
@@ -1,4 +1,4 @@
-This directory has a simple testing setup for testing the api.opentreeoflife.org 
+This directory has a simple testing setup for testing the (dev)api.opentreeoflife.org 
 web services. Either write test.conf or run one of the 2*conf.sh scripts
 before you run the tests.
 
@@ -23,6 +23,22 @@ Run all of the tests using:
   * configuration settings may be made from the command line; these
     override settings from test.conf.  They are passed as command line
     arguments of the form section:param=value, e.g. host:allowwrite=false
+
+Here are some of the configuration settings: (all for 'host' section,
+see test.conf for config file examples)
+
+  * apihost - base URL for all tests, the part preceding "/v2",
+    perhaps including a port number.  Value should start with 'http'
+    and should not end with '/'.
+  * allowwrite - true or false, default true.  If false, suppress any
+    tests that might have a side effect (e.g. writing to a
+    phylesystem).  Default true.  Useful for checking a production server.
+  * translate - true or false, default false.  If true, URLs are first
+    rewritten the same way the open tree apache server would rewrite
+    them before being used in an HTTP request.  This is intended for
+    local testing in the absence of a locally configured apache
+    server.  This allows tests to be written in terms of advertised /v2
+    URLs even if they are not directly supported by the web2py or neo4j server.
 
 If VERBOSE_TESTING is in the env when you execute a test, you'll get more
 verbose output.

--- a/ws-tests/opentreetesting.py
+++ b/ws-tests/opentreetesting.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# This file has been copied to the ws-tests directory of some other
+# open tree repositories.  Please propagate improvements to these
+# other copies.
+
 from ConfigParser import SafeConfigParser
 from cStringIO import StringIO
 import requests
@@ -231,6 +236,6 @@ translations = [('/v2/study/', '/phylesystem/v1/study/'),
 def translate(s):
     if config('host', 'translate', 'false') == 'true':
         for (src, dst) in translations:
-            if s.startswith(src):
-                return dst + s[len(src):]
+            if src in s:
+                return s.replace(src, dst)
     return s


### PR DESCRIPTION
This feature permits local testing in the absence of a configured apache server.  It is not currently in use in the phylesystem-api repo, because all of the tests use native web2py URLs instead of /v2 URLs. But now that it's there we might consider updating the tests to use the /v2 URLs instead of the native web2py URLs.

I have tested this locally, where it doesn't do any translations, and also tested the same code running in the taxomachine repo, where it does.

Also added some more information to ws-tests/README.md.