### PR TITLE
Treat incoming Markdown as a named argument.

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -65,10 +65,9 @@ def _markdown_to_html(markdown_src='', open_links_in_new_window=False):
                       html)
     return html
 
-def render_markdown():
+def render_markdown(src):
     # Convert POSTed Markdown to HTML (e.g., for previews in web UI)
-    markdown_src = request.body.read()
-    return _markdown_to_html( markdown_src, open_links_in_new_window=True )
+    return _markdown_to_html( src, open_links_in_new_window=True )
 
 def _raise_HTTP_from_msg(msg):
     raise HTTP(400, json.dumps({"error": 1, "description": msg}))


### PR DESCRIPTION
This is expected by web2py. In fact, it's not clear to me why the old version (which expected no arguments but yanked the entire payload from the HTTP request) worked at all! There are no significant code changes (server- or client-side) since it was known to be working, so I'm guessing it's some kind of change in routing behavior, or something to do with redirects to HTTPS...? Very strange.

In any case, this (along with a matching client-side tweak) fixes [a big in the main `opentree` repo](https://github.com/OpenTreeOfLife/opentree/issues/814).