### PR TITLE
Fix and simplify api urls

### DIFF
--- a/bin/add_or_update_webhooks.py
+++ b/bin/add_or_update_webhooks.py
@@ -6,22 +6,23 @@ import json, requests, sys
 this_script = sys.argv[0]
 
 if len(sys.argv) > 1:
-	opentree_docstore_url = sys.argv[1]
+    opentree_docstore_url = sys.argv[1]
 else:
     print "Please specify the Open Tree doc-store URL as first argument: '%s <repo-URL> <public-API-URL> [<GitHub-OAuth-token-file>]'" % (this_script,)
     sys.exit(1)  # signal to the caller that something went wrong
 
 if len(sys.argv) > 2:
-	opentree_api_base_url = sys.argv[2].rstrip("/")
+    opentree_api_base_url = sys.argv[2].rstrip("/")
+    nudge_index_url = "%s/phylesystem/search/nudgeIndexOnUpdates" % opentree_api_base_url
 else:
     print "Please specify the Open Tree API public URL as second argument: '%s <repo-URL> <public-API-URL> [<GitHub-OAuth-token-file>]'" % (this_script,)
     sys.exit(1)  # signal to the caller that something went wrong
- 
+
 if len(sys.argv) > 3:
-	oauth_token_file = sys.argv[3]
+    oauth_token_file = sys.argv[3]
 else:
     oauth_token_file = None
- 
+
 # To do this automatically via the GitHub API, we need an OAuth token for bot
 # user 'opentreeapi' on GitHub, with scope 'public_repo' and permission to
 # manage hooks. This is stored in yet another sensitive file.
@@ -54,7 +55,7 @@ if not(prompt_for_manual_webhooks):
             if (hook.get('name') == "web" and 
                 hook.get('active') == True and
                 hook.get('events') and ("push" in hook['events']) and
-                hook.get('config') and (hook['config']['url'] == "%s/../search/nudgeIndexOnUpdates" % opentree_api_base_url)
+                hook.get('config') and (hook['config']['url'] == nudge_index_url)
             ):
                 found_matching_webhook = True
         except:
@@ -73,7 +74,7 @@ if not(prompt_for_manual_webhooks):
                 "push"
             ],
             "config": {
-                "url": ("%s/../search/nudgeIndexOnUpdates" % opentree_api_base_url),
+                "url": nudge_index_url,
                 "content_type": "json"
             }
         }
@@ -101,12 +102,12 @@ if prompt_for_manual_webhooks:
         %s/settings/hooks
         
     Find (or add) a webhook with these properties:
-        Payload URL: %s/../search/nudgeIndexOnUpdates
+        Payload URL: %s
         Payload version: application/vnd.github.v3+json
         Events: push
         Active: true
 
     ***************************************************************
-        """ %  (opentree_docstore_url, opentree_api_base_url)
+        """ %  (opentree_docstore_url, nudge_index_url)
 
 sys.exit(0)

--- a/controllers/default.py
+++ b/controllers/default.py
@@ -436,7 +436,7 @@ def collection(*args, **kwargs):
             raise HTTP(404, "Collection '{s}' has no JSON data!".format(s=collection_id))
         # add/restore the url field (using the visible fetch URL)
         base_url = api_utils.get_collections_api_base_url(request)
-        collection_json['url'] = '{b}/collection/{i}'.format(b=base_url,
+        collection_json['url'] = '{b}/v2/collection/{i}'.format(b=base_url,
                                                             i=collection_id)
         try:
             external_url = collections.get_public_url(collection_id)
@@ -595,7 +595,7 @@ def _fetch_duplicate_study_ids(study_DOI=None, study_ID=None):
         # if no DOI exists, there are no known duplicates
         return [ ]
     oti_base_url = api_utils.get_oti_base_url(request)
-    fetch_url = '%s/singlePropertySearchForStudies' % oti_base_url
+    fetch_url = '%s/oti/v1/singlePropertySearchForStudies' % oti_base_url
     try:
         dupe_lookup_response = fetch(
             fetch_url,

--- a/controllers/search.py
+++ b/controllers/search.py
@@ -36,7 +36,7 @@ other than specifying a port, even if URL encoded.
             conf.read("%s/applications/%s/private/config" % (os.path.abspath('.'), app_name,))
 
         oti_base_url = conf.get("apis", "oti_base_url")
-        api_base_url = "%s/ext/QueryServices/graphdb/" % (oti_base_url,)
+        api_base_url = "%s/oti/ext/QueryServices/graphdb/" % (oti_base_url,)
 
         opentree_docstore_url = conf.get("apis", "opentree_docstore_url")
 
@@ -73,7 +73,7 @@ N.B. This depends on a GitHub webhook on the chosen docstore.
         conf.read("%s/applications/%s/private/config" % (os.path.abspath('.'), app_name,))
 
     oti_base_url = conf.get("apis", "oti_base_url")
-    api_base_url = "%s/ext/QueryServices/graphdb/" % (oti_base_url,)
+    api_base_url = "%s/oti/ext/QueryServices/graphdb/" % (oti_base_url,)
 
     opentree_docstore_url = conf.get("apis", "opentree_docstore_url")
     payload = request.vars
@@ -124,8 +124,7 @@ N.B. This depends on a GitHub webhook on the chosen docstore.
     add_or_update_ids = list(set(add_or_update_ids))  # remove any duplicates
 
     if len(add_or_update_ids) > 0:
-        # N.B. The indexing service lives outside of the v1/ space, so we "back out" these URLs with ".."
-        nudge_url = "%s/../ext/IndexServices/graphdb/indexNexsons" % (oti_base_url,)
+        nudge_url = "%s/oti/ext/IndexServices/graphdb/indexNexsons" % (oti_base_url,)
         nexson_urls = [ (nexson_url_template % (study_id,)) for study_id in add_or_update_ids ]
 
         # N.B. that gluon.tools.fetch() can't be used here, since it won't send
@@ -153,8 +152,7 @@ nexson_urls: %s
 
     if len(removed_study_ids) > 0:
         # Un-index the studies that were removed from docstore
-        # N.B. The indexing service lives outside of the v1/ space, so we "back out" these URLs with ".."
-        remove_url = "%s/../ext/IndexServices/graphdb/unindexNexsons" % (oti_base_url,)
+        remove_url = "%s/oti/ext/IndexServices/graphdb/unindexNexsons" % (oti_base_url,)
         req = urllib2.Request(
             url=remove_url, 
             data=json.dumps({


### PR DESCRIPTION
Support the new use of domain-only base URLs in system-config files. To do this, we tweak the internal definition of some API URLs to use the older, versioned URLs. This also modifies the on-commit webhook on GitHub.

Addresses #176. These changes are running now on **devtree**.

**IMPORTANT:** Once this PR is merged to master, we'll need to update [the production api config file](https://github.com/OpenTreeOfLife/deployed-systems/blob/295557c3f24864f5f2a9954a1287e4cfebd4987b/production/api.config#L24-L28) to match [the domain-only base URLs used in devapi](https://github.com/OpenTreeOfLife/deployed-systems/blob/295557c3f24864f5f2a9954a1287e4cfebd4987b/development/devapi.config#L23-L29).