### PR TITLE
Add amendment ws-tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 
 install:
    - "git clone https://github.com/OpenTreeOfLife/peyotl.git && cd peyotl && pip install -r requirements.txt &&  python setup.py develop && cd .. "
-   - pip install -r requirements.txt --use-mirrors
+   - pip install -r requirements.txt
    # Travis builder defaults don't play nicely with multiprocessing.Queue
    - "sudo rm -rf /dev/shm && sudo ln -s /run/shm /dev/shm"
 

--- a/ws-tests/README.md
+++ b/ws-tests/README.md
@@ -15,7 +15,7 @@ Run all of the tests using:
   * 2globalconf.sh copies the global testing config to the active location
   * 2localconf.sh copies the local testing config to the active location.
   * test_*.py should take no arguments and use its exit code to indicate
-        passing or failing the tests.
+        passing (0), failing (1), or skipping (3) the tests
   * run_tests.sh runs all of the test_*.py files and summarizes the number
         of tests and failures.
   * to suppress tests that have side effects (PUT/POST), set configuration

--- a/ws-tests/global.test.conf
+++ b/ws-tests/global.test.conf
@@ -1,3 +1,3 @@
 [host]
-apihost = http://devapi.opentreeoflife.org
+apihost = https://devapi.opentreeoflife.org
 parentsha = f604e027cdd0ada6638e620206a9f44edbabeff3

--- a/ws-tests/local.test.conf
+++ b/ws-tests/local.test.conf
@@ -1,5 +1,7 @@
 [host]
 apihost = http://127.0.0.1:8000
+# NOTE that for current OpenTree dev and production API servers, this URL
+# should use HTTPS.
 
 # hbf_phylesystem_test
 #parentsha = f604e027cdd0ada6638e620206a9f44edbabeff3

--- a/ws-tests/test_amendment_get_404.py
+++ b/ws-tests/test_amendment_get_404.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+# this amendment does not exist
+SUBMIT_URI = DOMAIN + '/v3/amendment/additions-0000000-99999999'
+if test_http_json_method(SUBMIT_URI, 'GET', expected_status=404):
+    sys.exit(0)
+sys.exit(1)

--- a/ws-tests/test_amendment_list.py
+++ b/ws-tests/test_amendment_list.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + 'v3/amendments/list_all'
+r = test_http_json_method(SUBMIT_URI,
+                          'GET',
+                          expected_status=200,
+                          return_bool_data=True)
+if not r[0]:
+    sys.exit(1)
+#print r[1]

--- a/ws-tests/test_amendment_list.py
+++ b/ws-tests/test_amendment_list.py
@@ -2,7 +2,7 @@
 import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + 'v3/amendments/list_all'
+SUBMIT_URI = DOMAIN + '/v3/amendments/list_all'
 r = test_http_json_method(SUBMIT_URI,
                           'GET',
                           expected_status=200,

--- a/ws-tests/test_study_get_multiformat.py
+++ b/ws-tests/test_study_get_multiformat.py
@@ -51,23 +51,26 @@ def dict_eq(a, b):
             sys.stdout.write('  keys in b only "{a}"."\n'.format(a=bo))
             d = False
     for k in ka:
-        va = a[k]
-        vb = b[k]
-        if va != vb:
-            if isinstance(va, dict) and isinstance(vb, dict):
-                if not dict_eq(va, vb):
-                    d = False
-            elif isinstance(va, list) and isinstance(vb, list):
-                for n, ela in enumerate(va):
-                    elb = vb[n]
-                    if not dict_eq(ela, elb):
+        if k in kb:
+            va = a[k]
+            vb = b[k]
+            if va != vb:
+                if isinstance(va, dict) and isinstance(vb, dict):
+                    if not dict_eq(va, vb):
                         d = False
-                if len(va) != len(vb):
+                elif isinstance(va, list) and isinstance(vb, list):
+                    for n, ela in enumerate(va):
+                        elb = vb[n]
+                        if not dict_eq(ela, elb):
+                            d = False
+                    if len(va) != len(vb):
+                        d = False
+                        sys.stdout.write('  lists for {} differ in length.\n'.format(k))
+                else:
                     d = False
-                    sys.stdout.write('  lists for {} differ in length.\n'.format(k))
-            else:
-                d = False
-                sys.stdout.write('  value for {k}: "{a}" != "{b}"\n'.format(k=k, a=va, b=vb))
+                    sys.stdout.write('  value for {k}: "{a}" != "{b}"\n'.format(k=k, a=va, b=vb))
+        else:
+            d = False
     return d
 
 


### PR DESCRIPTION
Basic checks for amendment services, patterned after those for collections. Tested against devapi, using OAuth token and allowwrite=true. 
```bash
cd phylesystem-api/ws-tests
#export GITHUB_OAUTH_TOKEN={YOUR-TOKEN-HERE}
#export VERBOSE_TESTING=1  # optional, for verbose output
bash run_tests.sh
```

Also tested from the main test runner in germinator:
```bash
cd germinator
#export VERBOSE_TESTING=1  # optional, for verbose output
ws-tests/run_tests.sh \
    -t ../phylesystem-api/ws-tests \
    https://devapi.opentreeoflife.org
```

This also includes a minor fix, specifying HTTPS for test-domain URLs in the default configuration. (Otherwise some tests failed due to the unexpected response code from our redirect from HTTP to HTTPS.)