### PR TITLE
Reduce dependence on conf files.

### DIFF
--- a/ws-tests/test_valid_study_put_override_author.py
+++ b/ws-tests/test_valid_study_put_override_author.py
@@ -6,8 +6,25 @@ import json
 import sys
 import os
 
+SCRIPT_NAME = os.path.split(sys.argv[0])[1]
+auth_token = os.environ.get('GITHUB_OAUTH_TOKEN')
+if auth_token is None:
+    sys.stderr.write('{} skipped due to lack of GITHUB_OAUTH_TOKEN in env\n')
+    sys.exit(3)
+
+# this makes it easier to test concurrent pushes to different branches
+study_id = "12"
 DOMAIN = config('host', 'apihost')
-starting_commit_SHA = config('host', 'parentsha')
+URL = DOMAIN + '/phylesystem/v1/study/%s' % study_id
+r = test_http_json_method(URL,
+                          'GET',
+                          expected_status=200,
+                          return_bool_data=True,
+                          headers={'content-type':'text/plain', 'accept':'text/plain'},
+                          is_json=True)
+if not r[0]:
+    sys.exit(1)
+starting_commit_SHA = r[1]['branch2sha']['master']
 
 study_id="12"
 SUBMIT_URI = DOMAIN + '/phylesystem/v1/study/{s}'.format(s=study_id)


### PR DESCRIPTION
These 2 tests used to get the parentsha for a commit
from the test.conf file. That worked and isolated GET
failure from these PUT tests. But it is tedious to keep
the parentsha in sync with the server against which you
are running the tests. Given that we really need the
GET to be working to use the system at all, I've gone
ahead and made these tests get the parentsha from the
response of the GET rather than the conf file.