### PR TITLE
Peyotl cleanup

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -5,8 +5,7 @@ import json
 import anyjson
 import traceback
 from sh import git
-from peyotl import can_convert_nexson_forms, convert_nexson_format
-from peyotl.utility.str_util import slugify
+from peyotl import convert_nexson_format
 from peyotl.phylesystem.git_workflows import GitWorkflowError, \
                                              validate_and_convert_nexson
 from peyotl.collections import OWNER_ID_PATTERN, \
@@ -16,7 +15,6 @@ from peyotl.amendments import AMENDMENT_ID_PATTERN
 from peyotl.amendments.validation import validate_amendment
 from peyotl.nexson_syntax import get_empty_nexson, \
                                  extract_supporting_file_messages, \
-                                 extract_tree, \
                                  PhyloSchema, \
                                  read_as_json, \
                                  BY_ID_HONEY_BADGERFISH

--- a/controllers/studies.py
+++ b/controllers/studies.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from peyotl.api import OTI, APIDomains
+from peyotl.api import OTI
 import api_utils
 import json
 def _raise400(msg):

--- a/modules/api_utils.py
+++ b/modules/api_utils.py
@@ -4,7 +4,6 @@ from peyotl.phylesystem import Phylesystem
 from peyotl.collections import TreeCollectionStore
 from peyotl.amendments import TaxonomicAmendmentStore
 from peyotl.utility import read_config as read_peyotl_config
-from peyotl.utility import get_config as get_peyotl_config
 from ConfigParser import SafeConfigParser
 from datetime import datetime
 import tempfile

--- a/ws-tests/config_test_valid_study_put.py
+++ b/ws-tests/config_test_valid_study_put.py
@@ -21,8 +21,6 @@ n = resp['data']
 # refresh a timestamp so that the test generates a commit
 m = n['nexml']['^bogus_timestamp'] = datetime.datetime.utcnow().isoformat()
 
-#from peyotl import write_as_json
-#write_as_json(n, '9-0.0.0.json')
 data = { 'nexson' : n,
          'auth_token': os.environ.get('GITHUB_OAUTH_TOKEN', 'bogus_token'),
          'starting_commit_SHA': starting_commit_SHA,

--- a/ws-tests/test_valid_study_put.py
+++ b/ws-tests/test_valid_study_put.py
@@ -23,8 +23,6 @@ m = n['nexml']['^bogus_timestamp'] = datetime.datetime.utcnow().isoformat()
 
 exit_if_api_is_readonly(__file__)
 
-#from peyotl import write_as_json
-#write_as_json(n, '9-0.0.0.json')
 data = { 'nexson' : n,
          'auth_token': os.environ.get('GITHUB_OAUTH_TOKEN', 'bogus_token'),
          'starting_commit_SHA': starting_commit_SHA,


### PR DESCRIPTION
This just removes imports from peyotl that are unused in the code.

Note that this also includes the changes in the confless-tests.py branch (merging the separate PR for that will reduce the # of commits in this PR).