### PR TITLE
hmm. need some hacks to support the version namespaced and bare forms of the external_url

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -117,7 +117,10 @@ def unmerged_branches():
 def external_url():
     response.view = 'generic.json'
     try:
-        study_id = request.args[1]
+        study_id = request.args[0]
+        # hacky way to support */external_url/STUDY_ID and */v1/external_url/STUDY_ID
+        if study_id == 'external_url':
+            study_id = request.args[1]
     except:
         raise HTTP(400, '{"error": 1, "description": "Expecting study_id as the argument"}')
     phylesystem = api_utils.get_phylesystem(request)


### PR DESCRIPTION
My previous PR (issue-116 branch) did not realize that in one spot (in peyotl) we were expecting the URL to have a "v1/" in the URL, and in the other test (in phylesystem-api/ws-tests) we lack any version specifier.

Thanks to web2py's quirky routing (or perhaps our poor use of said routing) this affects the request.args list. This code will support either URL (at the cost of breaking if we ever have a study with the study_id=external_url given that we don't mint IDs that have that form, that seems like an ignoreable wart).