### PR TITLE
Update URLs for (un)indexing studies in oti.

### DIFF
--- a/controllers/search.py
+++ b/controllers/search.py
@@ -174,8 +174,7 @@ def _otindex_remove_studies(remove_ids, otindex_base_url):
         raise HTTP(500, json.dumps({"description": "Unexpected error calling otindex: {}".format(e.message)}))
 
 def _oti_add_update_studies( add_or_update_ids, oti_base_url, nexson_url_template ):
-    # N.B. The indexing service lives outside of the v1/ space, so we "back out" these URLs with ".."
-    nudge_url = "%s/../ext/IndexServices/graphdb/indexNexsons" % (oti_base_url,)
+    nudge_url = "{b}oti/ext/IndexServices/graphdb/indexNexsons".format(b=oti_base_url)
     nexson_urls = [ (nexson_url_template % (study_id,)) for study_id in add_or_update_ids ]
 
     # EXAMPLE of a working curl call to nudge index:
@@ -206,9 +205,7 @@ def _oti_add_update_studies( add_or_update_ids, oti_base_url, nexson_url_templat
 
 def _oti_remove_studies( remove_ids, oti_base_url, nexson_url_template ):
     # Un-index the studies that were removed from docstore
-    # N.B. The indexing service lives outside of the v1/ space,
-    # so we "back out" these URLs with ".."
-    remove_url = "%s/../ext/IndexServices/graphdb/unindexNexsons" % (oti_base_url,)
+    remove_url = "{b}oti/ext/IndexServices/graphdb/unindexNexsons".format(b=oti_base_url)
     req = urllib2.Request(
         url=remove_url,
         data=json.dumps({

--- a/controllers/search.py
+++ b/controllers/search.py
@@ -209,7 +209,7 @@ def _oti_remove_studies( remove_ids, oti_base_url, nexson_url_template ):
     req = urllib2.Request(
         url=remove_url,
         data=json.dumps({
-            "ids": removed_study_ids
+            "ids": remove_ids
         }),
         headers={"Content-Type": "application/json"}
     )
@@ -222,8 +222,8 @@ def _oti_remove_studies( remove_ids, oti_base_url, nexson_url_template ):
         exc_type, exc_value, exc_traceback = sys.exc_info()
         msg = """unindexNexsons failed!'
             remove_url: %s
-            removed_study_ids: %s
-            %s""" % (remove_url, removed_study_ids, traceback.format_exception(exc_type, exc_value, exc_traceback),)
+            remove_ids: %s
+            %s""" % (remove_url, remove_ids, traceback.format_exception(exc_type, exc_value, exc_traceback),)
     return msg
 
 def nudgeTaxonIndexOnUpdates():


### PR DESCRIPTION
This is working now on **devapi**, see [successful webhook results](https://github.com/OpenTreeOfLife/phylesystem-0/settings/hooks/8924536#delivery-response) for confirmation. N.B I've also hot-fixed this on production **api**, so we should clear those changes before the next update.