### PR TITLE
Manage (include or exclude) trees in synth

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -235,7 +235,7 @@ def include_tree_in_synth(study_id=None, tree_id=None, **kwargs):
             __deferred_push_to_gh_call(request, default_collection_id, doc_type='collection', **kwargs)
 
     # fetch and return the updated list of synth-input trees
-    return json.dumps( trees_in_synth(valist, kwargs) )
+    return json.dumps( trees_in_synth(kwargs) )
 
 def exclude_tree_from_synth(study_id=None, tree_id=None, **kwargs):
     #import pdb; pdb.set_trace()
@@ -289,7 +289,7 @@ def exclude_tree_from_synth(study_id=None, tree_id=None, **kwargs):
                 __deferred_push_to_gh_call(request, coll_id, doc_type='collection', **kwargs)
 
     # fetch and return the updated list of synth-input trees
-    return json.dumps( trees_in_synth(valist, kwargs) )
+    return json.dumps( trees_in_synth(kwargs) )
 
 
 def study_list():

--- a/controllers/default.py
+++ b/controllers/default.py
@@ -156,8 +156,8 @@ def include_tree_in_synth(study_id=None, tree_id=None, **kwargs):
         response.view = 'generic.jsonp'
     else:
         response.view = 'generic.json'
-    study_id = study_id.strip()
-    tree_id = tree_id.strip()
+    study_id = (study_id or "").strip()
+    tree_id = (tree_id or "").strip()
     # check for empty/missing ids
     if (study_id == '') or (tree_id == ''):
         raise HTTP(400, '{"error": 1, "description": "Expecting study_id and tree_id arguments"}')
@@ -238,8 +238,8 @@ def exclude_tree_from_synth(study_id=None, tree_id=None, **kwargs):
         response.view = 'generic.jsonp'
     else:
         response.view = 'generic.json'
-    study_id = study_id.strip()
-    tree_id = tree_id.strip()
+    study_id = (study_id or "").strip()
+    tree_id = (tree_id or "").strip()
     # check for empty/missing ids
     if (study_id == '') or (tree_id == ''):
         raise HTTP(400, '{"error": 1, "description": "Expecting study_id and tree_id arguments"}')

--- a/controllers/default.py
+++ b/controllers/default.py
@@ -235,7 +235,7 @@ def include_tree_in_synth(study_id=None, tree_id=None, **kwargs):
             __deferred_push_to_gh_call(request, default_collection_id, doc_type='collection', **kwargs)
 
     # fetch and return the updated list of synth-input trees
-    return json.dumps( trees_in_synth(kwargs) )
+    return trees_in_synth(kwargs)
 
 def exclude_tree_from_synth(study_id=None, tree_id=None, **kwargs):
     #import pdb; pdb.set_trace()
@@ -289,7 +289,7 @@ def exclude_tree_from_synth(study_id=None, tree_id=None, **kwargs):
                 __deferred_push_to_gh_call(request, coll_id, doc_type='collection', **kwargs)
 
     # fetch and return the updated list of synth-input trees
-    return json.dumps( trees_in_synth(kwargs) )
+    return trees_in_synth(kwargs)
 
 
 def study_list():

--- a/controllers/default.py
+++ b/controllers/default.py
@@ -171,7 +171,7 @@ def include_tree_in_synth(study_id=None, tree_id=None, **kwargs):
                 found_tree = tree
         found_tree_name = found_tree['@label'] or tree_id
     except:  # report a missing/misidentified tree
-        raise HTTP(404, '{"error": 1, "description": "Specified tree \'t{}\' in study \'s{}\' not found! Save this study and try again?"}'.format(s=study_id,t=tree_id))
+        raise HTTP(404, '{{"error": 1, "description": "Specified tree \'{t}\' in study \'{s}\' not found! Save this study and try again?"}}'.format(s=study_id,t=tree_id))
     already_included_in_synth_input_collections = False
     # Look ahead to see if it's already in an included collection; if so, skip
     # adding it again.

--- a/controllers/default.py
+++ b/controllers/default.py
@@ -204,7 +204,7 @@ def include_tree_in_synth(study_id=None, tree_id=None, **kwargs):
         # update (or add) the decision list for this collection
         coll['decisions'] = decision_list
         # update the default collection (forces re-indexing)
-        auth_info = auth_info or api_utils.authenticate(**kwargs)
+        auth_info = api_utils.authenticate(**kwargs)
         owner_id = auth_info.get('login', None)
         parent_sha = kwargs.get('starting_commit_SHA', None)
         merged_sha = None  #TODO: kwargs.get('???', None)
@@ -246,7 +246,7 @@ def exclude_tree_from_synth(study_id=None, tree_id=None, **kwargs):
     # find this tree in ANY synth-input collection; if found, remove it and update the collection
     coll_id_list = _get_synth_input_collection_ids()
     cds = api_utils.get_tree_collection_store(request)
-    auth_info = auth_info or api_utils.authenticate(**kwargs)
+    auth_info = api_utils.authenticate(**kwargs)
     owner_id = auth_info.get('login', None)
     for coll_id in coll_id_list:
         try:


### PR DESCRIPTION
This builds on the same-named branch of peyotl, to directly support including/excluding trees in the synthesis-input collections (specified by system configuration).

The diff here is somewhat misleading, in that @mtholder previously committed a complete `trees_in_synth` function but it's broken up by the new and refactored code below.

Anyway, this is running now on **devapi**.