### PR TITLE
Support Unicode in collection comments (when adding a tree)

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -203,7 +203,7 @@ def include_tree_in_synth(study_id=None, tree_id=None, **kwargs):
             'studyID': study_id,
             'SHA': "",
             'decision': "INCLUDED",
-            'comments': "Added via API (include_tree_in_synth) from {p}".format(p=found_study.get('nexml')['^ot:studyPublicationReference'])
+            'comments': u"Added via API (include_tree_in_synth) from {p}".format(p=found_study.get('nexml')['^ot:studyPublicationReference'])
             })
         # update (or add) the decision list for this collection
         coll['decisions'] = decision_list


### PR DESCRIPTION
We construct a special comment when including trees in synthesis, and this was failing if the study's publication reference included Unicode characters. This should fix it ([tested on dev](https://github.com/OpenTreeOfLife/collections-0/commit/dcf89735869ec89f3179ea39bb57c37e97da6749)).

Thanks for catching this, @bredelings!