### PR TITLE
Avoid cache poisoning by raising API-fetch errors

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -393,12 +393,16 @@ def cached():
         the_response = urllib2.urlopen(req).read()
         ##pprint('RESPONSE:')
         ##pprint(the_response)
+        #print '...returning a sensible urllib2 response...'
         return the_response
-
+    except urllib2.URLError, e:
+        # throw a web2py exception (copying status code and message from urllib2.URLError) so we don't poison the cache!
+        # REMINDER: By default, Web2py's RAM cache will ignore any response whose code doesn't match 1xx, 2xx, or 3xx!
+        #print '>>> urllib2.URLError! TRYING TO RETURN ITS VALUES IN A WEB2PY EXCEPTION...'
+        raise HTTP(e.code, e.reason)
     except Exception, e:
-        # throw 403 or 500 or just leave it
-        return ('ERROR', e.message)
-
+        #print '>>> some other Exception! TRYING TO RETURN ITS VALUES IN A WEB2PY EXCEPTION...'
+        raise HTTP(500, 'Unknown exception in cached call!')
 
 
 def reponexsonformat():


### PR DESCRIPTION
In order to avoid poisoning our cache with failed API calls, we should preserve any failed response code during API calls, and raise appropriate (web2py-class) exceptions. This will pass the error directly back to the client (and troubleshooters), _and_ ensure that the bad response is ignored by web2py's RAM cache.

N.B. By default, webp2y's RAM cache will ignore any response with status codes other than 1xx, 2xx, 3xx. We can narrow that further to only cache 200 responses, but I believe urllib2 will successfully follow some of the other response types (e.g. redirects) and fill the cache properly.