### PR TITLE
We should return the response body from API calls

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -399,8 +399,8 @@ def cached():
     except urllib2.URLError, e:
         # throw a web2py exception (copying status code and message from urllib2.URLError) so we don't poison the cache!
         # REMINDER: By default, Web2py's RAM cache will ignore any response whose code doesn't match 1xx, 2xx, or 3xx!
-        #print '>>> urllib2.URLError! TRYING TO RETURN ITS VALUES IN A WEB2PY EXCEPTION...'
-        raise HTTP(e.code, e.reason)
+        # NOTE that we won't cache this response, but we DO want to return its payload
+        raise HTTP(e.code, e.read())
     except Exception, e:
         #print '>>> some other Exception! TRYING TO RETURN ITS VALUES IN A WEB2PY EXCEPTION...'
         raise HTTP(500, 'Unknown exception in cached call!')


### PR DESCRIPTION
We don't cache these, but sometimes the payload is informative.

This is working now on **devapi**, see for example https://devtree.opentreeoflife.org/opentree/argus/ottol@34907/Drosophila

(Use the dev tools to see a failed `subtree` call (response code=400), and the full response body.)