### PR TITLE
Convert duplicate-study results to bare study IDs

### DIFF
--- a/phylesystem_api/phylesystem_api/views/study.py
+++ b/phylesystem_api/phylesystem_api/views/study.py
@@ -182,11 +182,12 @@ def _fetch_duplicate_study_ids(request, study_DOI=None, study_ID=None):
     duplicate_study_ids = oti.find_studies(
         {"ot:studyPublication": study_DOI}, verbose=False, exact=True
     )
+    # strip the list to just include bare study IDs
+    duplicate_study_ids = [x['ot:studyId'] for x in duplicate_study_ids]
     try:
         duplicate_study_ids.remove(study_ID)
     except ValueError:
         # ignore error, if oti is lagging and doesn't have this study yet
-        pass
         pass
     return duplicate_study_ids
 


### PR DESCRIPTION
This should restore proper our check for duplicates study IDs, which was mangled during Pyramid conversion and subsequent refactoring. Available for testing on **devtree**, see for instance https://devtree.opentreeoflife.org/curator/study/view/tt_266