### PR TITLE
Force collection download to JSON file

### DIFF
--- a/phylesystem_api/phylesystem_api/views/collection.py
+++ b/phylesystem_api/phylesystem_api/views/collection.py
@@ -69,14 +69,13 @@ def fetch_collection(request):
     # NB - This method does not require authentication!
     collection_id = request.matchdict["collection_id"]
 
-    """
+    # if '.json' was added to the URL, specify as download
     if collection_id.endswith('.json'):
-        collection_id = collection_id.substring()
+        # save this as a filename WITHOUT slashes
+        preferred_filename = collection_id.replace('/','_')
         # ADD content-disposition header
-    """
-    # specify as download for bare URL (not from webapp)
-    preferred_filename = collection_id.replace('/','_')
-    Response.content_disposition('attachment; filename={}.json;'.format(preferred_filename))
+        Response.content_disposition('attachment; filename={}.json;'.format(preferred_filename))
+        collection_id = collection_id[0:-5]  # trim the '.json' extension and proceed w/ fetch
 
     result = fetch_doc(
         request,

--- a/phylesystem_api/phylesystem_api/views/collection.py
+++ b/phylesystem_api/phylesystem_api/views/collection.py
@@ -68,6 +68,16 @@ def is_valid_collection_id(doc_id):
 def fetch_collection(request):
     # NB - This method does not require authentication!
     collection_id = request.matchdict["collection_id"]
+
+    """
+    if collection_id.endswith('.json'):
+        collection_id = collection_id.substring()
+        # ADD content-disposition header
+    """
+    # specify as download for bare URL (not from webapp)
+    preferred_filename = collection_id.replace('/','_')
+    Response.content_disposition('attachment; filename={}.json;'.format(preferred_filename))
+
     result = fetch_doc(
         request,
         doc_id=collection_id,

--- a/phylesystem_api/phylesystem_api/views/collection.py
+++ b/phylesystem_api/phylesystem_api/views/collection.py
@@ -75,15 +75,10 @@ def fetch_collection(request):
         preferred_filename = collection_id.replace('/','_')
         # ADD content-disposition header
         response = request.response
-        _LOG.debug("response? ", response)
-        #_LOG.debug("response.content_disposition? ", response.content_disposition)
-        #_LOG.debug("response.headers? ", response.headers)
-        #_LOG.debug("OLD response.headers['Content-Disposition']? ", response.headers['Content-Disposition'])
-        #response.content_disposition('attachment; filename={}.json;'.format(preferred_filename))
-        request.response.headers["Content-Disposition"] = "attachment; filename={};".format(preferred_filename)
+        response.headers["Content-Disposition"] = "attachment; filename={};".format(preferred_filename)
         _LOG.debug("NEW response.headers['Content-Disposition']? ", response.headers['Content-Disposition'])
         collection_id = collection_id[0:-5]  # trim the '.json' extension and proceed w/ fetch
-        _LOG.debug("NEW collection_id? ", collection_id)
+        _LOG.debug("SHORTENED collection_id? ", collection_id)
 
     result = fetch_doc(
         request,

--- a/phylesystem_api/phylesystem_api/views/collection.py
+++ b/phylesystem_api/phylesystem_api/views/collection.py
@@ -91,7 +91,6 @@ def fetch_collection(request):
     return add_collection_specific_fields(request, collection_id, result)
 
 
-
 def add_collection_specific_fields(request, collection_id, result):
     collection_json = result["data"]
     # Add commentHTML to result JSON

--- a/phylesystem_api/phylesystem_api/views/collection.py
+++ b/phylesystem_api/phylesystem_api/views/collection.py
@@ -75,8 +75,15 @@ def fetch_collection(request):
         preferred_filename = collection_id.replace('/','_')
         # ADD content-disposition header
         response = request.response
-        response.content_disposition('attachment; filename={}.json;'.format(preferred_filename))
+        _LOG.debug("response? ", response)
+        _LOG.debug("response.content_disposition? ", response.content_disposition)
+        _LOG.debug("response.headers? ", response.headers)
+        _LOG.debug("OLD response.headers['Content-Disposition']? ", response.headers['Content-Disposition'])
+        #response.content_disposition('attachment; filename={}.json;'.format(preferred_filename))
+        request.response.headers["Content-Disposition"] = "attachment; filename={}.json;".format(preferred_filename)
+        _LOG.debug("NEW response.headers['Content-Disposition']? ", response.headers['Content-Disposition'])
         collection_id = collection_id[0:-5]  # trim the '.json' extension and proceed w/ fetch
+        _LOG.debug("NEW collection_id? ", collection_id)
 
     result = fetch_doc(
         request,

--- a/phylesystem_api/phylesystem_api/views/collection.py
+++ b/phylesystem_api/phylesystem_api/views/collection.py
@@ -74,7 +74,7 @@ def fetch_collection(request):
         # save this as a filename WITHOUT slashes
         preferred_filename = collection_id.replace('/','_')
         # ADD content-disposition header
-        Response.content_disposition('attachment; filename={}.json;'.format(preferred_filename))
+        request.response.content_disposition('attachment; filename={}.json;'.format(preferred_filename))
         collection_id = collection_id[0:-5]  # trim the '.json' extension and proceed w/ fetch
 
     result = fetch_doc(

--- a/phylesystem_api/phylesystem_api/views/collection.py
+++ b/phylesystem_api/phylesystem_api/views/collection.py
@@ -76,9 +76,9 @@ def fetch_collection(request):
         # ADD content-disposition header
         response = request.response
         _LOG.debug("response? ", response)
-        _LOG.debug("response.content_disposition? ", response.content_disposition)
-        _LOG.debug("response.headers? ", response.headers)
-        _LOG.debug("OLD response.headers['Content-Disposition']? ", response.headers['Content-Disposition'])
+        #_LOG.debug("response.content_disposition? ", response.content_disposition)
+        #_LOG.debug("response.headers? ", response.headers)
+        #_LOG.debug("OLD response.headers['Content-Disposition']? ", response.headers['Content-Disposition'])
         #response.content_disposition('attachment; filename={}.json;'.format(preferred_filename))
         request.response.headers["Content-Disposition"] = "attachment; filename={}.json;".format(preferred_filename)
         _LOG.debug("NEW response.headers['Content-Disposition']? ", response.headers['Content-Disposition'])

--- a/phylesystem_api/phylesystem_api/views/collection.py
+++ b/phylesystem_api/phylesystem_api/views/collection.py
@@ -80,7 +80,7 @@ def fetch_collection(request):
         #_LOG.debug("response.headers? ", response.headers)
         #_LOG.debug("OLD response.headers['Content-Disposition']? ", response.headers['Content-Disposition'])
         #response.content_disposition('attachment; filename={}.json;'.format(preferred_filename))
-        request.response.headers["Content-Disposition"] = "attachment; filename={}.json;".format(preferred_filename)
+        request.response.headers["Content-Disposition"] = "attachment; filename={};".format(preferred_filename)
         _LOG.debug("NEW response.headers['Content-Disposition']? ", response.headers['Content-Disposition'])
         collection_id = collection_id[0:-5]  # trim the '.json' extension and proceed w/ fetch
         _LOG.debug("NEW collection_id? ", collection_id)

--- a/phylesystem_api/phylesystem_api/views/collection.py
+++ b/phylesystem_api/phylesystem_api/views/collection.py
@@ -76,9 +76,7 @@ def fetch_collection(request):
         # ADD content-disposition header
         response = request.response
         response.headers["Content-Disposition"] = "attachment; filename={};".format(preferred_filename)
-        _LOG.debug("NEW response.headers['Content-Disposition']? ", response.headers['Content-Disposition'])
         collection_id = collection_id[0:-5]  # trim the '.json' extension and proceed w/ fetch
-        _LOG.debug("SHORTENED collection_id? ", collection_id)
 
     result = fetch_doc(
         request,

--- a/phylesystem_api/phylesystem_api/views/collection.py
+++ b/phylesystem_api/phylesystem_api/views/collection.py
@@ -74,7 +74,8 @@ def fetch_collection(request):
         # save this as a filename WITHOUT slashes
         preferred_filename = collection_id.replace('/','_')
         # ADD content-disposition header
-        request.response.content_disposition('attachment; filename={}.json;'.format(preferred_filename))
+        response = request.response
+        response.content_disposition('attachment; filename={}.json;'.format(preferred_filename))
         collection_id = collection_id[0:-5]  # trim the '.json' extension and proceed w/ fetch
 
     result = fetch_doc(
@@ -86,6 +87,7 @@ def fetch_collection(request):
         add_version_history=True,
     )
     return add_collection_specific_fields(request, collection_id, result)
+
 
 
 def add_collection_specific_fields(request, collection_id, result):


### PR DESCRIPTION
Returning to our old behavior of appending '.json' to a collection fetch URL to set the `Content-Disposition` response header to download a file, and giving that file a sensible name. This matches the existing behavior for study fetch in our APIs. (Look for a [companion pull request](https://github.com/OpenTreeOfLife/opentree/pull/1338) in the opentree/webapp repo.)